### PR TITLE
Create browser-based vocabulary trainer interface

### DIFF
--- a/vocab-converter/package.json
+++ b/vocab-converter/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "start": "node web-server.js",
+    "cli": "node vocab_test.js",
+    "convert": "node convert.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/vocab-converter/public/app.js
+++ b/vocab-converter/public/app.js
@@ -1,0 +1,191 @@
+const statsEl = document.getElementById('stats');
+const englishEl = document.getElementById('english');
+const translationEl = document.getElementById('translation');
+const revealBtn = document.getElementById('reveal');
+const keepBtn = document.getElementById('keep');
+const deleteBtn = document.getElementById('delete');
+const resetBtn = document.getElementById('reset');
+const startBtn = document.getElementById('start');
+const messageEl = document.getElementById('message');
+const speakBtn = document.getElementById('speak');
+const questionCounter = document.getElementById('question-counter');
+
+let currentWord = null;
+let finished = false;
+
+function updateStats(stats = {}) {
+  if (!stats.total && stats.total !== 0) {
+    statsEl.textContent = '尚未載入檔案';
+    questionCounter.textContent = '-- / --';
+    return;
+  }
+
+  statsEl.innerHTML = `
+    <span>總共：${stats.total}</span>
+    <span>剩餘：${stats.remaining}</span>
+    <span>本輪已答：${stats.answered} / ${stats.maxQuestions}</span>
+  `;
+  questionCounter.textContent = `${Math.min(stats.answered + 1, stats.maxQuestions)} / ${stats.maxQuestions}`;
+}
+
+function setMessage(text, type = 'info') {
+  messageEl.textContent = text || '';
+  messageEl.dataset.type = type;
+}
+
+function toggleControls(disabled) {
+  revealBtn.disabled = disabled;
+  keepBtn.disabled = disabled;
+  deleteBtn.disabled = disabled;
+  speakBtn.disabled = disabled;
+}
+
+function resetCard() {
+  currentWord = null;
+  englishEl.textContent = '請按「開始測驗」';
+  translationEl.textContent = '';
+  translationEl.classList.add('hidden');
+  toggleControls(true);
+}
+
+async function fetchState() {
+  try {
+    const res = await fetch('/api/state');
+    if (!res.ok) {
+      throw new Error('無法取得狀態');
+    }
+    const data = await res.json();
+    updateStats(data.stats);
+    finished = data.finished;
+    if (finished) {
+      setMessage('目前沒有題目，請重新載入或增加單字。', 'warn');
+    }
+  } catch (error) {
+    setMessage(error.message, 'error');
+  }
+}
+
+async function loadWord() {
+  if (finished) {
+    setMessage('此回合已結束，請重新載入。', 'warn');
+    return;
+  }
+
+  try {
+    const res = await fetch('/api/word');
+    if (!res.ok) {
+      throw new Error('取得單字時發生錯誤');
+    }
+    const data = await res.json();
+
+    updateStats(data.stats);
+
+    if (data.finished) {
+      finished = true;
+      toggleControls(true);
+      startBtn.disabled = false;
+      setMessage('此回合結束！按「開始測驗」重新開始。', 'info');
+      englishEl.textContent = '🎉 完成本回合';
+      translationEl.textContent = '';
+      translationEl.classList.add('hidden');
+      return;
+    }
+
+    currentWord = data.word;
+    englishEl.textContent = currentWord.en;
+    translationEl.textContent = currentWord.zh;
+    translationEl.classList.add('hidden');
+    toggleControls(false);
+    revealBtn.focus();
+    setMessage('');
+  } catch (error) {
+    setMessage(error.message, 'error');
+  }
+}
+
+async function sendAction(action) {
+  if (!currentWord) {
+    setMessage('請先載入單字', 'warn');
+    return;
+  }
+
+  try {
+    const res = await fetch('/api/word/action', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: currentWord.id, action }),
+    });
+
+    if (!res.ok) {
+      const error = await res.json();
+      throw new Error(error.message || '操作失敗');
+    }
+
+    const data = await res.json();
+    updateStats(data.stats);
+
+    if (data.finished) {
+      finished = true;
+      toggleControls(true);
+      startBtn.disabled = false;
+      englishEl.textContent = '🎉 完成本回合';
+      translationEl.textContent = '';
+      translationEl.classList.add('hidden');
+      setMessage('本回合結束，按「開始測驗」重來。', 'info');
+      return;
+    }
+
+    currentWord = null;
+    loadWord();
+  } catch (error) {
+    setMessage(error.message, 'error');
+  }
+}
+
+async function resetSession() {
+  try {
+    const res = await fetch('/api/session/reset', { method: 'POST' });
+    if (!res.ok) {
+      throw new Error('重設失敗');
+    }
+    const data = await res.json();
+    finished = data.finished;
+    updateStats(data.stats);
+    resetCard();
+    startBtn.disabled = false;
+    setMessage('已重新載入檔案並重設回合。', 'info');
+  } catch (error) {
+    setMessage(error.message, 'error');
+  }
+}
+
+function revealTranslation() {
+  translationEl.classList.remove('hidden');
+}
+
+function speakWord() {
+  if (!currentWord || !('speechSynthesis' in window)) {
+    return;
+  }
+
+  const utterance = new SpeechSynthesisUtterance(currentWord.en.replace(/["']/g, ''));
+  utterance.lang = 'en-US';
+  window.speechSynthesis.cancel();
+  window.speechSynthesis.speak(utterance);
+}
+
+startBtn.addEventListener('click', () => {
+  finished = false;
+  startBtn.disabled = true;
+  loadWord();
+});
+
+revealBtn.addEventListener('click', revealTranslation);
+keepBtn.addEventListener('click', () => sendAction('keep'));
+deleteBtn.addEventListener('click', () => sendAction('delete'));
+resetBtn.addEventListener('click', resetSession);
+speakBtn.addEventListener('click', speakWord);
+
+fetchState();
+resetCard();
+

--- a/vocab-converter/public/index.html
+++ b/vocab-converter/public/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vocabulary Trainer</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header>
+        <h1>Vocabulary Trainer</h1>
+        <p class="subtitle">從 RVOCA.ini 快速進行單字測驗與管理</p>
+      </header>
+
+      <section class="stats" id="stats"></section>
+
+      <section class="card" id="card">
+        <div class="card-header">
+          <span class="badge" id="question-counter">-- / --</span>
+          <button type="button" class="ghost" id="speak" aria-label="朗讀單字">
+            🔈 朗讀
+          </button>
+        </div>
+        <p class="english" id="english">請按「開始測驗」</p>
+        <p class="translation hidden" id="translation"></p>
+        <button type="button" class="primary" id="reveal">顯示中文</button>
+      </section>
+
+      <section class="actions">
+        <button type="button" class="secondary" id="start">開始測驗</button>
+        <button type="button" class="primary" id="keep" disabled>保留</button>
+        <button type="button" class="danger" id="delete" disabled>刪除並從檔案移除</button>
+      </section>
+
+      <section class="footer">
+        <button type="button" class="ghost" id="reset">重新載入檔案並重來</button>
+      </section>
+
+      <p class="message" id="message"></p>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/vocab-converter/public/styles.css
+++ b/vocab-converter/public/styles.css
@@ -1,0 +1,168 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Noto Sans TC', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background-color: #0f172a;
+  background-image: radial-gradient(circle at 20% 20%, #1e293b 0, rgba(15, 23, 42, 0) 60%),
+    radial-gradient(circle at 80% 0%, #0ea5e9 0, rgba(14, 165, 233, 0) 45%);
+  min-height: 100%;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #f8fafc;
+}
+
+.container {
+  width: min(680px, 94vw);
+  padding: 2.5rem;
+  border-radius: 24px;
+  backdrop-filter: blur(14px);
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: grid;
+  gap: 1.5rem;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 2rem;
+  letter-spacing: 0.08em;
+}
+
+.subtitle {
+  margin: 0.25rem 0 0;
+  color: #cbd5f5;
+}
+
+.stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  font-size: 0.95rem;
+  color: #e2e8f0;
+}
+
+.card {
+  padding: 1.75rem;
+  border-radius: 20px;
+  background: rgba(30, 41, 59, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  display: grid;
+  gap: 1rem;
+  min-height: 220px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.18);
+  color: #f0f9ff;
+  font-weight: 600;
+}
+
+.english {
+  font-size: 1.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+
+.translation {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #bae6fd;
+}
+
+.hidden {
+  visibility: hidden;
+}
+
+.actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
+button {
+  font: inherit;
+  border: none;
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.primary {
+  background: linear-gradient(135deg, #38bdf8, #0284c7);
+  color: #0f172a;
+  font-weight: 700;
+}
+
+.secondary {
+  background: rgba(148, 163, 184, 0.2);
+  color: #e2e8f0;
+  font-weight: 600;
+}
+
+.danger {
+  background: linear-gradient(135deg, #f87171, #ef4444);
+  color: #fee2e2;
+  font-weight: 700;
+}
+
+.ghost {
+  background: transparent;
+  color: #94a3b8;
+  padding: 0.25rem 0.6rem;
+}
+
+button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(2, 132, 199, 0.15);
+}
+
+button:not(:disabled):active {
+  transform: translateY(0);
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.message {
+  min-height: 1.5rem;
+  color: #f8fafc;
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: 1.75rem;
+  }
+
+  .english {
+    font-size: 1.45rem;
+  }
+}

--- a/vocab-converter/web-server.js
+++ b/vocab-converter/web-server.js
@@ -1,0 +1,243 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3000;
+const FILE_PATH = path.join(__dirname, 'RVOCA.ini');
+const PUBLIC_DIR = path.join(__dirname, 'public');
+const MAX_QUESTIONS = 15;
+
+const hasCJK = (s) => /[\u4E00-\u9FFF\u3040-\u30FF\uAC00-\uD7AF]/.test(s);
+
+function splitEnZh(line) {
+  const tokens = line.split(/\s+/);
+  const cjkIndex = tokens.findIndex((t) => hasCJK(t));
+
+  if (cjkIndex > 0) {
+    return {
+      en: tokens.slice(0, cjkIndex).join(' '),
+      zh: tokens.slice(cjkIndex).join(' '),
+    };
+  }
+
+  const [en, ...zhParts] = tokens;
+  return { en, zh: zhParts.join(' ') };
+}
+
+function loadWords() {
+  const raw = fs
+    .readFileSync(FILE_PATH, 'utf8')
+    .replace(/^\uFEFF/, '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  return raw.map((line, index) => ({ id: index, order: index, ...splitEnZh(line) }));
+}
+
+function saveWords(words) {
+  const lines = words
+    .sort((a, b) => a.order - b.order)
+    .map((word) => `${word.en} ${word.zh}`);
+
+  fs.writeFileSync(FILE_PATH, lines.join('\n'), 'utf8');
+}
+
+let wordList = loadWords();
+let remaining = [...wordList];
+let sessionAnswered = 0;
+let lastWordId = null;
+
+const getStats = () => ({
+  total: wordList.length,
+  remaining: remaining.length,
+  answered: sessionAnswered,
+  maxQuestions: MAX_QUESTIONS,
+});
+
+function getRandomWord() {
+  if (!remaining.length) {
+    return null;
+  }
+
+  if (remaining.length === 1) {
+    lastWordId = remaining[0].id;
+    return remaining[0];
+  }
+
+  let word = null;
+  for (let i = 0; i < 5; i += 1) {
+    const candidate = remaining[Math.floor(Math.random() * remaining.length)];
+    if (candidate.id !== lastWordId) {
+      word = candidate;
+      break;
+    }
+  }
+
+  if (!word) {
+    word = remaining[Math.floor(Math.random() * remaining.length)];
+  }
+
+  lastWordId = word.id;
+  return word;
+}
+
+function sessionFinished() {
+  return sessionAnswered >= MAX_QUESTIONS || remaining.length === 0;
+}
+
+function sendJson(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+function handleApi(req, res, url) {
+  if (req.method === 'GET' && url.pathname === '/api/state') {
+    sendJson(res, 200, { stats: getStats(), finished: sessionFinished() });
+    return true;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/word') {
+    if (sessionFinished()) {
+      sendJson(res, 200, { finished: true, stats: getStats() });
+      return true;
+    }
+
+    const word = getRandomWord();
+    if (!word) {
+      sendJson(res, 200, { finished: true, stats: getStats() });
+      return true;
+    }
+
+    sendJson(res, 200, { word, stats: getStats() });
+    return true;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/word/action') {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+      if (body.length > 1e6) {
+        req.destroy();
+      }
+    });
+    req.on('end', () => {
+      try {
+        const data = body ? JSON.parse(body) : {};
+        const { id, action } = data;
+
+        if (typeof id !== 'number' || !action) {
+          sendJson(res, 400, { message: '缺少必要的資料。' });
+          return;
+        }
+
+        const word = wordList.find((item) => item.id === id);
+        if (!word) {
+          sendJson(res, 404, { message: '找不到指定的單字。' });
+          return;
+        }
+
+        if (action === 'delete') {
+          wordList = wordList.filter((item) => item.id !== id);
+          remaining = remaining.filter((item) => item.id !== id);
+          saveWords(wordList);
+        } else if (action === 'keep') {
+          // Do nothing besides counting the answer.
+        } else {
+          sendJson(res, 400, { message: '未知的操作。' });
+          return;
+        }
+
+        sessionAnswered += 1;
+
+        if (sessionFinished()) {
+          sendJson(res, 200, { finished: true, stats: getStats() });
+          return;
+        }
+
+        sendJson(res, 200, { finished: false, stats: getStats() });
+      } catch (error) {
+        sendJson(res, 400, { message: '資料格式錯誤。' });
+      }
+    });
+    return true;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/session/reset') {
+    wordList = loadWords();
+    remaining = [...wordList];
+    sessionAnswered = 0;
+    lastWordId = null;
+
+    sendJson(res, 200, { stats: getStats(), finished: false });
+    return true;
+  }
+
+  return false;
+}
+
+function getContentType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case '.html':
+      return 'text/html; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.js':
+      return 'application/javascript; charset=utf-8';
+    case '.json':
+      return 'application/json; charset=utf-8';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.svg':
+      return 'image/svg+xml';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (url.pathname.startsWith('/api/')) {
+    const handled = handleApi(req, res, url);
+    if (!handled) {
+      sendJson(res, 404, { message: '未知的 API 路徑。' });
+    }
+    return;
+  }
+
+  let filePath = url.pathname;
+  if (filePath === '/' || filePath === '') {
+    filePath = '/index.html';
+  }
+
+  const resolvedPath = path.join(PUBLIC_DIR, filePath);
+  if (!resolvedPath.startsWith(PUBLIC_DIR)) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+
+  fs.stat(resolvedPath, (err, stats) => {
+    if (err || !stats.isFile()) {
+      res.writeHead(404);
+      res.end('Not Found');
+      return;
+    }
+
+    res.writeHead(200, { 'Content-Type': getContentType(resolvedPath) });
+    fs.createReadStream(resolvedPath).pipe(res);
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Vocabulary web app ready on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- implement a lightweight HTTP server that serves the existing vocabulary data and exposes actions for marking items kept or deleted
- design a responsive single-page interface with speech synthesis support to quiz words directly from the browser
- add npm scripts to launch the web UI, the CLI trainer, and the Excel conversion utility

## Testing
- curl http://localhost:3000/api/state
- curl http://localhost:3000/api/word
- curl -X POST http://localhost:3000/api/word/action -H 'Content-Type: application/json' -d '{"id":206,"action":"keep"}'

------
https://chatgpt.com/codex/tasks/task_e_68e5d82eda3883239917c18a40fadf00